### PR TITLE
Encourage to use `pip` instead `setup.py`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,23 +66,22 @@ throughout the conversion.
  Installation
 **************
 
-At present we recommend installing Code-Scribe in development mode
+At present we recommend installing Code-Scribe in an virtual environment:
 
 .. code::
 
-   ./setup develop
+   python3 -m venv env
+   source env/bin/activate
+   pip install --upgrade pip
 
-Development mode enables testing of features/updates directly from the
-source code and is an effective method for debugging. Note that the
-``setup`` script relies on ``click``, which can be installed using,
+And install Code-Scribe using the ``pip`` in editable mode:
 
 .. code::
 
-   pip install click
+   pip install -e .
 
-The ``code-scribe`` script is installed in ``$HOME/.local/bin``
-directory and therefore the environment variable, ``PATH``, should be
-updated to include this location for command line use.
+Editable mode enables testing of features/updates directly from the
+source code and is an effective method for debugging.
 
 *******
  Usage

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ throughout the conversion.
  Installation
 **************
 
-At present we recommened installing Code-Scribe in development mode
+At present we recommend installing Code-Scribe in development mode
 
 .. code::
 
@@ -81,7 +81,7 @@ source code and is an effective method for debugging. Note that the
    pip install click
 
 The ``code-scribe`` script is installed in ``$HOME/.local/bin``
-directory and therfore the environment variable, ``PATH``, should be
+directory and therefore the environment variable, ``PATH``, should be
 updated to include this location for command line use.
 
 *******
@@ -108,7 +108,7 @@ understanding of their functionality
      inspect    Perform a generative AI inspection on Fortran files
      translate  Perform a generative AI conversion of Fortran files
 
-Following is a breif overview of different commands:
+Following is a brief overview of different commands:
 
 #. ``code-scribe index <project_root_dir>`` - Parses the project
    directory tree and creates a ``scribe.yaml`` file at each node along
@@ -148,7 +148,7 @@ Following is a breif overview of different commands:
    generative AI. You can either download a model locally from
    huggingface and provide it as an option to ``-m`` or you can simply
    set ``-m openai`` to use OpenAI API to perform code translation. Note
-   that ``-m openai`` requires the environemnt variable
+   that ``-m openai`` requires the environment variable
    ``OPENAI_API_KEY`` to be set. The ``<prompt.toml>`` is a chat
    template that guides AI to perform code translation using the source
    and draft ``.scribe`` files.
@@ -179,8 +179,8 @@ Following is a breif overview of different commands:
 
 #. ``code-scribe translate <filelist> -p <seed_prompt.toml>
    --save-prompts``: This command allows generation of file specific
-   json chat template that one can copy/paste to chat interfaces like
-   that of ChatGPT to generate the source code. The json files are
+   JSON chat template that one can copy/paste to chat interfaces like
+   that of ChatGPT to generate the source code. The JSON files are
    created from the seed prompt file and appended with source and draft
    code.
 
@@ -213,7 +213,7 @@ Following is a breif overview of different commands:
 
       export OPENAI_API_KEY="your_openai_api_key_here"
 
-   And you have installed the openai library
+   And you have installed the OpenAI library
 
    .. code::
 

--- a/code_scribe/cli/_code_scribe.py
+++ b/code_scribe/cli/_code_scribe.py
@@ -18,7 +18,7 @@ def code_scribe(ctx: click.Context, version: bool) -> None:
     """
     if ctx.invoked_subcommand is None and not version:
         subprocess.run(
-            "export PATH=~/.local/bin:/usr/local/bin:$PATH && code-scribe --help",
+            "code-scribe --help",
             shell=True,
             check=True,
         )

--- a/code_scribe/cli/_code_scribe.py
+++ b/code_scribe/cli/_code_scribe.py
@@ -2,7 +2,7 @@
 
 # Standard libraries
 import subprocess
-import metadata
+from importlib import metadata
 
 # Feature libraries
 import click
@@ -24,4 +24,4 @@ def code_scribe(ctx: click.Context, version: bool) -> None:
         )
 
     if version:
-        click.echo(metadata.__version__)
+        click.echo(metadata.version("CodeScribe"))

--- a/code_scribe/cli/_code_scribe.py
+++ b/code_scribe/cli/_code_scribe.py
@@ -2,7 +2,7 @@
 
 # Standard libraries
 import subprocess
-import pkg_resources
+import metadata
 
 # Feature libraries
 import click
@@ -24,4 +24,4 @@ def code_scribe(ctx: click.Context, version: bool) -> None:
         )
 
     if version:
-        click.echo(pkg_resources.require("CodeScribe")[0].version)
+        click.echo(metadata.__version__)

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,5 @@
 click
+requests
 toml
 pyyaml
 pypandoc


### PR DESCRIPTION
As the direct usage of `setup.py` as a command-line tool is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/), it would be better to encourage users to use `pip` to install the CodeScribe in a virtual environment.

Additionally, this PR deletes a hard dependency on `setuptools` (i.e., `pkg_resources`) by using `importlib`. 