### PR TITLE
Support OpenAI-compatible endpoints (Ollama)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -304,6 +304,45 @@ Following is a brief overview of different commands:
    ARGO models are recommended for users with access to the Argonne
    network.
 
+#. **OpenAI-Compatible Endpoints (Ollama, etc.)**: Code-Scribe supports
+   any OpenAI-compatible API endpoint, making it easy to use on-premises
+   models such as Ollama. To use an OpenAI-compatible endpoint, specify
+   `-m oaic-<model>` where `<model>` is the model name served by your
+   endpoint. For example, to use a locally running Ollama instance with
+   `llama3.1`:
+
+   .. code:: bash
+
+      ▶ code-scribe translate <filelist> -m oaic-llama3.1 -p <seed_prompt.toml>
+
+   Before running the command, set the following environment variables:
+
+   .. code:: bash
+
+      # Required: Base URL of the OpenAI-compatible API (must include /v1)
+      export OPENAI_COMP_BASEURL="http://localhost:11434/v1"
+
+      # Required: Provider label (used internally for auth routing)
+      export OPENAI_COMP_PROVIDER="ollama"
+
+      # Optional: API key (usually not needed for local Ollama)
+      export OPENAI_COMP_APIKEY=""
+
+   Alternatively, you can use `-m oaic-env` to read the model name from
+   the `OPENAI_COMP_MODEL` environment variable:
+
+   .. code:: bash
+
+      export OPENAI_COMP_MODEL="llama3.1"
+      ▶ code-scribe translate <filelist> -m oaic-env -p <seed_prompt.toml>
+
+   This approach is useful when you want to switch models without
+   changing the command line.
+
+   **Note**: For ALCF inference endpoints, set `OPENAI_COMP_PROVIDER` to
+   a value containing `alcf` (e.g., `alcf-inference`) and ensure
+   `ALCF_INFERENCE_APIKEY` is set.
+
 #. **Saving Custom Prompts**: Instead of selecting a model and running
    the commands interactively, you can also save the generated prompts
    for later use. Use the `--save-prompts` flag to store the prompts in

--- a/code_scribe/lib/_llm.py
+++ b/code_scribe/lib/_llm.py
@@ -11,21 +11,31 @@ from alive_progress import alive_bar
 from code_scribe import lib
 
 
-class OpencodeModel:
-    def __init__(self) -> None:
+class OpenAICompModel:
+    def __init__(self, model: str) -> None:
         openai = importlib.import_module("openai")
 
-        self.baseurl = os.getenv("OPENCODE_CODESCRIBE_BASEURL")
-        self.provider = os.getenv("OPENCODE_CODESCRIBE_PROVIDER")
-        self.model = os.getenv("OPENCODE_CODESCRIBE_MODEL")
+        self.baseurl = os.getenv("OPENAI_COMP_BASEURL")
+        if not self.baseurl:
+            raise ValueError("OPENAI_COMP_BASEURL environment variable is not set")
 
-        print(self.baseurl, self.provider, self.model)
+        self.provider = os.getenv("OPENAI_COMP_PROVIDER")
+        if not self.provider:
+            raise ValueError("OPENAI_COMP_PROVIDER environment variable is not set")
 
-        if "alcf" in self.provider:
+        if model.lower() == "env":
+            self.model = os.getenv("OPENAI_COMP_MODEL")
+        else:
+            self.model = model
+
+        if os.getenv("OPENAI_COMP_APIKEY"):
+            self.apikey = os.getenv("OPENAI_COMP_APIKEY")
+
+        elif "alcf" in self.provider:
             self.apikey = os.getenv("ALCF_INFERENCE_APIKEY")
             if not self.apikey:
                 raise ValueError(
-                    "ARGO_INFERENCE_APIKEY environment variable is not set"
+                    "ALCF_INFERENCE_APIKEY environment variable is not set"
                 )
         else:
             self.apikey = "null"
@@ -338,14 +348,14 @@ def _set_neural_model(model: Union[Path, str]) -> object:
     if os.path.exists(model):
         neural_model = TFModel(model)
 
+    elif model.lower().startswith("oaic-"):
+        neural_model = OpenAICompModel(model.lower().strip("oaic")[1:])
+
     elif model.lower().startswith("openai-"):
         neural_model = OpenAIModel(model.lower().strip("openai")[1:])
 
     elif model.lower().startswith("argo-"):
         neural_model = ArgoModel(model.lower().strip("argo")[1:])
-
-    elif model.lower() == "opencode-env":
-        neural_model = OpencodeModel()
 
     elif model.lower() == "kimi":
         neural_model = KimiModel()

--- a/opencode/plugins/csb_plugin_codescribe.ts
+++ b/opencode/plugins/csb_plugin_codescribe.ts
@@ -98,10 +98,10 @@ export const ProviderModelPlugin: Plugin = async ({ client }) => {
  * Commands:
  *   - index <directory>: Index Fortran files, create scribe.yaml
  *   - draft <file>: Generate draft .scribe file with C++ annotations
- *   - translate <file> -p <prompt.toml>: Translate Fortran to C++ (always uses -m opencode-env)
- *   - inspect <files> -q "<query>": Query/analyze source files (always uses -m opencode-env)
- *   - update <files> -p <prompt.toml> -q "<query>" [-r <ref>...]: Update existing files (always uses -m opencode-env)
- *   - generate <prompt> [-r <ref>...]: Generate new code (always uses -m opencode-env)
+ *   - translate <file> -p <prompt.toml>: Translate Fortran to C++ (always uses -m oaic-env)
+ *   - inspect <files> -q "<query>": Query/analyze source files (always uses -m oaic-env)
+ *   - update <files> -p <prompt.toml> -q "<query>" [-r <ref>...]: Update existing files (always uses -m oaic-env)
+ *   - generate <prompt> [-r <ref>...]: Generate new code (always uses -m oaic-env)
  *   - format <files>: Format TOML prompt files
  *
  * Command-specific rules:
@@ -124,13 +124,13 @@ Optionally sets OPENCODE_CODESCRIBE_* env vars (model/provider/baseURL) before r
 Commands:
   - index <directory>: Index Fortran project, creates scribe.yaml
   - draft <file>: Generate draft .scribe file (single Fortran file)
-  - translate <file> -p <prompt.toml>: Translate Fortran to C++ (Fortran files only, no -r; always uses -m opencode-env)
-  - inspect <files> -q "<query>": Analyze source files (always uses -m opencode-env)
-  - update <files> [-p <prompt.toml>] [-q "<query>"] [-r <ref>...]: Modify existing files (requires -p and/or -q; always uses -m opencode-env)
-  - generate <prompt> [-r <ref>...]: Generate new code (prompt is TOML path or string; always uses -m opencode-env)
+  - translate <file> -p <prompt.toml>: Translate Fortran to C++ (Fortran files only, no -r; always uses -m oaic-env)
+  - inspect <files> -q "<query>": Analyze source files (always uses -m oaic-env)
+  - update <files> [-p <prompt.toml>] [-q "<query>"] [-r <ref>...]: Modify existing files (requires -p and/or -q; always uses -m oaic-env)
+  - generate <prompt> [-r <ref>...]: Generate new code (prompt is TOML path or string; always uses -m oaic-env)
   - format <files>: Format TOML prompt files
 
-Note: The -m/--model CLI option is always set to "opencode-env" for commands that require it. Any user-provided -m/--model is ignored.
+Note: The -m/--model CLI option is always set to "oaic-env" for commands that require it. Any user-provided -m/--model is ignored.
 
 Example: codescribe translate src/Solver.F90 -p prompts/code_translation.toml`,
 
@@ -158,7 +158,7 @@ Example: codescribe translate src/Solver.F90 -p prompts/code_translation.toml`,
           const needsEnv = requiresProviderModel.has(command)
 
           // Enforced CLI model for commands that need it
-          const FORCED_CLI_MODEL = "opencode-env"
+          const FORCED_CLI_MODEL = "oaic-env"
 
           // Helper to strip any user-supplied -m/--model from args
           function stripModelArgs(argv: string[]): string[] {
@@ -251,12 +251,12 @@ Example: codescribe translate src/Solver.F90 -p prompts/code_translation.toml`,
             }
 
             // Set environment variables for the current Node session
-            process.env.OPENCODE_CODESCRIBE_MODEL = resolvedModel
-            process.env.OPENCODE_CODESCRIBE_PROVIDER = resolvedProvider
+            process.env.OPENAI_COMP_MODEL = resolvedModel
+            process.env.OPENAI_COMP_PROVIDER = resolvedProvider
             if (baseURL) {
-              process.env.OPENCODE_CODESCRIBE_BASEURL = baseURL
+              process.env.OPENAI_COMP_BASEURL = baseURL
             } else {
-              delete process.env.OPENCODE_CODESCRIBE_BASEURL
+              delete process.env.OPENAI_COMP_BASEURL
             }
             envSet = true
           }
@@ -264,7 +264,7 @@ Example: codescribe translate src/Solver.F90 -p prompts/code_translation.toml`,
           // Run the CLI
           const startTime = Date.now()
 
-          // Normalize args: strip any user-provided -m/--model and enforce -m opencode-env
+          // Normalize args: strip any user-provided -m/--model and enforce -m oaic-env
           const requiresCliModel = requiresProviderModel.has(command)
           const normalizedArgs = requiresCliModel ? stripModelArgs(args) : args
           const cliArgs = requiresCliModel


### PR DESCRIPTION
Closes #7

## Summary
- Add `OpenAICompModel` class to support any OpenAI-compatible API endpoint (e.g., Ollama)
- Introduce `oaic-<model>` model prefix for direct model selection and `oaic-env` for environment-based selection
- Update opencode plugin to set `OPENAI_COMP_*` environment variables for CLI integration
- Document usage in README.rst with examples for Ollama and ALCF inference endpoints

## Environment Variables
| Variable | Required | Description |
|----------|----------|-------------|
| `OPENAI_COMP_BASEURL` | Yes | Base URL of the OpenAI-compatible API (must include `/v1`) |
| `OPENAI_COMP_PROVIDER` | Yes | Provider label (used for auth routing) |
| `OPENAI_COMP_MODEL` | Only with `-m oaic-env` | Model name to use |
| `OPENAI_COMP_APIKEY` | No | API key (usually not needed for local Ollama) |

## Example Usage
```bash
# Set environment
export OPENAI_COMP_BASEURL="http://localhost:11434/v1"
export OPENAI_COMP_PROVIDER="ollama"

# Run translation with Ollama
code-scribe translate src/Solver.F90 -m oaic-llama3.1 -p prompts/code_translation.toml
```